### PR TITLE
refactor: replace status enums with union types

### DIFF
--- a/src/content/projects/active-ambassadors.md
+++ b/src/content/projects/active-ambassadors.md
@@ -6,7 +6,7 @@ imageAlt: 'Active Ambassadors logo, contianing a heart with a globe stating: Act
 published: 2020-12-21
 updated: 2020-12-21
 prio: 500
-status: INACTIVE
+status: inactive
 links:
   - title: Website
     url: https://active-ambassadors.org/

--- a/src/content/projects/arbeitskreis-boerse.md
+++ b/src/content/projects/arbeitskreis-boerse.md
@@ -6,7 +6,7 @@ imageAlt: 'Logo of the Arbeitskreis Börse: AKB Mannheim'
 published: 2020-12-21
 updated: 2020-12-21
 prio: 70
-status: INACTIVE
+status: inactive
 links:
   - title: Website
     url: https://www.akboerse.de/

--- a/src/content/projects/corona-warn-app.md
+++ b/src/content/projects/corona-warn-app.md
@@ -6,7 +6,7 @@ imageAlt: First screen of the Corona Warn App
 published: 2020-12-21
 updated: 2020-12-21
 prio: 1000
-status: INACTIVE
+status: inactive
 links:
   - title: Website
     url: https://www.coronawarn.app/en/

--- a/src/content/projects/cv-resume-template-figma.md
+++ b/src/content/projects/cv-resume-template-figma.md
@@ -6,7 +6,7 @@ imageAlt: Part of the CV template showing a picture, name and some relevant work
 published: 2020-12-21
 updated: 2023-11-07
 prio: 400
-status: ACTIVE
+status: active
 links:
   - title: Template
     url: https://www.figma.com/community/file/1128439910915950322/cv-resume-template-with-auto-layout-pdf-export

--- a/src/content/projects/greenkayak.md
+++ b/src/content/projects/greenkayak.md
@@ -6,7 +6,7 @@ imageAlt: First screen of the GreenKayak app on a device mockup
 published: 2023-11-07
 updated: 2023-11-07
 prio: 900
-status: INACTIVE
+status: inactive
 links:
   - title: Website
     url: https://www.greenkayak.org/

--- a/src/content/projects/q-summit.md
+++ b/src/content/projects/q-summit.md
@@ -6,7 +6,7 @@ imageAlt: Q-Summit logo which is an abstract Q
 published: 2020-12-21
 updated: 2023-11-07
 prio: 300
-status: INACTIVE
+status: inactive
 links:
   - title: Website
     url: https://q-summit.com/

--- a/src/content/projects/raft.md
+++ b/src/content/projects/raft.md
@@ -6,7 +6,7 @@ imageAlt: Self made raft with five people on it
 published: 2023-11-07
 updated: 2023-11-07
 prio: 800
-status: ACTIVE
+status: active
 links:
 tags:
   - Carpentry

--- a/src/content/projects/techmobshow.md
+++ b/src/content/projects/techmobshow.md
@@ -6,7 +6,7 @@ imageAlt: 'Podcast cover saying: Tech Mob Show by Henry Stoll, Jakob Möller and
 published: 2020-12-21
 updated: 2020-12-21
 prio: 200
-status: INACTIVE
+status: inactive
 links:
   - title: Instagram
     url: https://www.instagram.com/techmobshow/

--- a/src/content/projects/the-preneur.md
+++ b/src/content/projects/the-preneur.md
@@ -6,7 +6,7 @@ imageAlt: 'Podcast cover saying: The Preneur'
 published: 2020-12-21
 updated: 2020-12-21
 prio: 700
-status: INACTIVE
+status: inactive
 links:
   - title: Apple Podcast
     url: https://podcasts.apple.com/de/podcast/the-preneur/id1605492643?l=en

--- a/src/content/uses/airpod-pro-2.md
+++ b/src/content/uses/airpod-pro-2.md
@@ -4,7 +4,7 @@ description: 'Had the first version, got the second one but sadly still have the
 tags:
   - Hardware
 url: https://www.apple.com/airpods-pro/
-status: ACTIVE
+status: active
 image: airpod_pro2.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/alt-tab.md
+++ b/src/content/uses/alt-tab.md
@@ -4,7 +4,7 @@ description: 'A better and customizable version of CMD + Tab on Mavc.'
 tags:
   - Software
 url: https://alt-tab-macos.netlify.app/
-status: ACTIVE
+status: active
 image: alttab.png
 openSource: true
 updated: 2023-11-25 16:35

--- a/src/content/uses/anker-charger.md
+++ b/src/content/uses/anker-charger.md
@@ -4,7 +4,7 @@ description: 'As far as I know the smallest 100W charger (enough to charge a Mac
 tags:
   - Hardware
 url: https://www.anker.com/products/a2688-anker-prime-charger-100w-3-ports-gan?ref=naviMenu&variant=43931966079126
-status: ACTIVE
+status: active
 image: anker_charger.webp
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/anker-powerbank.md
+++ b/src/content/uses/anker-powerbank.md
@@ -4,7 +4,7 @@ description: "Had a MagSafe Powerbank but as I'm now on Android I needed a repla
 tags:
   - Hardware
 url: https://www.anker.com/products/a1259-built-in-cable-power-bank-10000mah?variant=42733233766550#reviews-jdgm
-status: ACTIVE
+status: active
 image: anker_powerbank.webp
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/apple-macbook-air.md
+++ b/src/content/uses/apple-macbook-air.md
@@ -4,7 +4,7 @@ description: 'Specs: M1 (Processor), 16 GB (Memory), 256 GB (Storage)'
 tags:
   - Hardware
 url: https://www.apple.com/de/macbook-air/
-status: ACTIVE
+status: active
 image: apple.svg
 openSource:
 updated: 2022-12-01 20:18

--- a/src/content/uses/asus-zenscreen-mb16ac.md
+++ b/src/content/uses/asus-zenscreen-mb16ac.md
@@ -4,7 +4,7 @@ description: 'Mobile display, powered over USB-C which gives me a dual display s
 tags:
   - Hardware
 url: https://www.asus.com/de/displays-desktops/monitors/zenscreen/zenscreen-mb16ac/
-status: INACTIVE
+status: inactive
 image: asus.svg
 openSource:
 updated: 2022-12-01 20:24

--- a/src/content/uses/bike.md
+++ b/src/content/uses/bike.md
@@ -4,7 +4,7 @@ description: 'All black city bike for my daily commute. I love it. Just a front 
 tags:
   - Essentials
 url: https://www.bike-components.de/en/Vortrieb/Modell-1-2-Men-s-Bike-p89918/
-status: ACTIVE
+status: active
 image: bike.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/bookmark-divider.md
+++ b/src/content/uses/bookmark-divider.md
@@ -4,7 +4,7 @@ description: 'A tool created by myself to use it as a bookmark divider between m
 tags:
   - Software
 url: https://bookmark-divider.netlify.app/
-status: ACTIVE
+status: active
 image: bookmarkdivider.svg
 openSource: true
 updated: 2022-12-01 20:32

--- a/src/content/uses/brew.md
+++ b/src/content/uses/brew.md
@@ -4,7 +4,7 @@ description: 'Installing all the stuff the easy way, for nerds on Mac.'
 tags:
   - Software
 url: https://brew.sh/
-status: ACTIVE
+status: active
 image: brew.svg
 openSource: true
 updated: 2023-11-25 16:35

--- a/src/content/uses/camelbak-bottle.md
+++ b/src/content/uses/camelbak-bottle.md
@@ -4,7 +4,7 @@ description: 'I fell in love with big water bottles, my old one broke and I got 
 tags:
   - Essentials
 url: https://www.camelbak.com/shop/water-bottles/everyday/chute-mag-32-oz-water-bottle-insulated-stainless-steel/CB-1516.html?dwvar_CB-1516_color=Moss
-status: ACTIVE
+status: active
 image: camelbak_bottle.webp
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/chatgpt.md
+++ b/src/content/uses/chatgpt.md
@@ -4,7 +4,7 @@ description: 'I have the Plus version from work. I use it in different situation
 tags:
   - Software
 url: https://chatgpt.com/
-status: ACTIVE
+status: active
 image: chatgpt.webp
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/clipy.md
+++ b/src/content/uses/clipy.md
@@ -4,7 +4,7 @@ description: 'A clipboard manager for macOS. No more, no less.'
 tags:
   - Software
 url: https://clipy-app.com/
-status: ACTIVE
+status: active
 image: clipy.png
 openSource: true
 updated: 2022-12-01 20:32

--- a/src/content/uses/electric-tape-blue.md
+++ b/src/content/uses/electric-tape-blue.md
@@ -4,7 +4,7 @@ description: "I'm getting around a bit, leacing with two room mates. I needed so
 tags:
   - Essentials
 url: https://www.tesa.com/en/industry/tesa-4308.html
-status: ACTIVE
+status: active
 image: blue_tape.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/elgato-ring-light.md
+++ b/src/content/uses/elgato-ring-light.md
@@ -4,7 +4,7 @@ description: 'Quite expansive, but the warmness (Kelvin) and brightness can be a
 tags:
   - Hardware
 url: https://www.elgato.com/en/ring-light
-status: INACTIVE
+status: inactive
 image: elgato.svg
 openSource:
 updated: 2022-12-01 20:20

--- a/src/content/uses/elgato-streamdeck.md
+++ b/src/content/uses/elgato-streamdeck.md
@@ -4,7 +4,7 @@ description: 'Programmable keyboard with displays which shows different keys dep
 tags:
   - Hardware
 url: https://www.elgato.com/en/stream-deck
-status: INACTIVE
+status: inactive
 image: elgato.svg
 openSource:
 updated: 2022-12-01 20:20

--- a/src/content/uses/enpass.md
+++ b/src/content/uses/enpass.md
@@ -4,7 +4,7 @@ description: 'I bought this password manager before they started the subscriptio
 tags:
   - Software
 url: https://www.enpass.io/
-status: ACTIVE
+status: active
 image: enpass.svg
 openSource:
 updated: 2022-12-01 20:29

--- a/src/content/uses/figma.md
+++ b/src/content/uses/figma.md
@@ -4,7 +4,7 @@ description: 'Awesome vector tool, you can work live at files and share them eas
 tags:
   - Software
 url: https://www.figma.com/
-status: ACTIVE
+status: active
 image: figma.svg
 openSource:
 updated: 2022-12-01 20:29

--- a/src/content/uses/fritzvold-wallet.md
+++ b/src/content/uses/fritzvold-wallet.md
@@ -4,7 +4,7 @@ description: "I'm not a fan of these sliding wallets, but I also want something 
 tags:
   - Essentials
 url: https://fritzvold.de/collections/geldborsen/products/minimal-wallet-erweitertes-muenzfach-rfid
-status: ACTIVE
+status: active
 image: fritzvold_wallet.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/ghostty.md
+++ b/src/content/uses/ghostty.md
@@ -4,7 +4,7 @@ description: 'Used Warp, but got to much AI, to much account, to much pushy in u
 tags:
   - Software
 url: https://ghostty.org/
-status: ACTIVE
+status: active
 image: ghostty.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/github-actions.md
+++ b/src/content/uses/github-actions.md
@@ -4,7 +4,7 @@ description: "As all my projects are on GitHub I'm just happy about such a simpl
 tags:
   - Development
 url: https://github.com/features/actions
-status: ACTIVE
+status: active
 image: githubactions.svg
 openSource:
 updated: 2022-12-01 20:26

--- a/src/content/uses/google-keep.md
+++ b/src/content/uses/google-keep.md
@@ -4,7 +4,7 @@ description: 'Use for more valatile notes, not knowledge that should be persiste
 tags:
   - Software
 url: https://keep.google.com/#home
-status: ACTIVE
+status: active
 image: google_keep.webp
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/google-workspace.md
+++ b/src/content/uses/google-workspace.md
@@ -4,7 +4,7 @@ description: 'In my case it is used privately, but it is also very easy to set u
 tags:
   - Software
 url: https://workspace.google.com
-status: ACTIVE
+status: active
 image: google.svg
 openSource:
 updated: 2022-12-01 20:34

--- a/src/content/uses/googlewebfontshelper.md
+++ b/src/content/uses/googlewebfontshelper.md
@@ -4,7 +4,7 @@ description: 'Tool to help you host Google fonts without the CDN. Why should you
 tags:
   - Development
 url: https://gwfh.mranftl.com/fonts
-status: ACTIVE
+status: active
 image:
 openSource: true
 updated: 2023-11-25 16:35

--- a/src/content/uses/ipad-air.md
+++ b/src/content/uses/ipad-air.md
@@ -4,7 +4,7 @@ description: 'Always wanted an iPad with a large screen to also use it as a seco
 tags:
   - Hardware
 url: https://www.apple.com/ipad-air/
-status: ACTIVE
+status: active
 image: ipair-air-m2.avif
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/logitech-streamcam.md
+++ b/src/content/uses/logitech-streamcam.md
@@ -4,7 +4,7 @@ description: 'Supports default mounting options and produces a pretty good Full 
 tags:
   - Hardware
 url: https://www.logitech.com/de-de/products/webcams/streamcam.960-001281.html
-status: INACTIVE
+status: inactive
 image: logitech.svg
 openSource:
 updated: 2022-12-01 20:21

--- a/src/content/uses/loop-earplugs.md
+++ b/src/content/uses/loop-earplugs.md
@@ -4,7 +4,7 @@ description: 'Got these earplugs recommended and have to say they fit perfectly,
 tags:
   - Essentials
 url: https://us.loopearplugs.com/products/quiet?variant=46599252803817
-status: ACTIVE
+status: active
 image: loop_earplug.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/macbook-pro-14-m2.md
+++ b/src/content/uses/macbook-pro-14-m2.md
@@ -4,7 +4,7 @@ description: 'My work laptop.'
 tags:
   - Hardware
 url: https://support.apple.com/en-us/111340
-status: ACTIVE
+status: active
 image: apple.svg
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/netlify.md
+++ b/src/content/uses/netlify.md
@@ -4,7 +4,7 @@ description: 'Connect Netlify to your repository to get a build when you push to
 tags:
   - Development
 url: https://www.netlify.com/
-status: ACTIVE
+status: active
 image: netlify.svg
 openSource:
 updated: 2022-12-01 20:22

--- a/src/content/uses/notion.md
+++ b/src/content/uses/notion.md
@@ -4,7 +4,7 @@ description: 'Used it for private stuff, heavily during my studies and now at wo
 tags:
   - Software
 url: https://www.notion.com/
-status: ACTIVE
+status: active
 image: notion.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/nuxtjs.md
+++ b/src/content/uses/nuxtjs.md
@@ -4,7 +4,7 @@ description: 'Opinionated meta framework for Vue.js.'
 tags:
   - Development
 url: https://nuxtjs.org/
-status: INACTIVE
+status: inactive
 image: nuxt.svg
 openSource: true
 updated: 2022-12-01 20:37

--- a/src/content/uses/perplexity.md
+++ b/src/content/uses/perplexity.md
@@ -4,7 +4,7 @@ description: "I use it for more complex search queries where I know I'll have to
 tags:
   - Software
 url: https://www.perplexity.ai/
-status: ACTIVE
+status: active
 image: perplexity.webp
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/pixel-9-pro.md
+++ b/src/content/uses/pixel-9-pro.md
@@ -4,7 +4,7 @@ description: 'Have been the last four years with the iPhone 12. Wanted to go bac
 tags:
   - Hardware
 url: https://store.google.com/product/pixel_9_pro
-status: ACTIVE
+status: active
 image: pixel_9_pro_pink.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/playwright.md
+++ b/src/content/uses/playwright.md
@@ -4,7 +4,7 @@ description: "A Node.js browser automation framework I use it to automate websit
 tags:
   - Development
 url: https://playwright.dev/
-status: ACTIVE
+status: active
 image: playwright.svg
 openSource: true
 updated: 2022-12-01 20:32

--- a/src/content/uses/raspberry-pi5.md
+++ b/src/content/uses/raspberry-pi5.md
@@ -4,7 +4,7 @@ description: 'Set up with Ansible and Docker, right now running Home Assistent w
 tags:
   - Hardware
 url: https://www.raspberrypi.com/products/raspberry-pi-5/
-status: ACTIVE
+status: active
 image: raspberry_pi_5.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/raycast.md
+++ b/src/content/uses/raycast.md
@@ -4,7 +4,7 @@ description: 'Nicer version of Spotlight for Mac.'
 tags:
   - Software
 url: https://www.raycast.com/
-status: ACTIVE
+status: active
 image: raycast.svg
 openSource: true
 updated: 2023-11-25 16:35

--- a/src/content/uses/rectangle.md
+++ b/src/content/uses/rectangle.md
@@ -4,7 +4,7 @@ description: 'Move and snap windows in macOS via mouse and shortcuts.'
 tags:
   - Software
 url: https://rectangleapp.com/
-status: ACTIVE
+status: active
 image: rectangle.png
 openSource: true
 updated: 2022-12-01 20:36

--- a/src/content/uses/rode-ntusb-mini.md
+++ b/src/content/uses/rode-ntusb-mini.md
@@ -4,7 +4,7 @@ description: 'Nice quality (as far as I can tell) and can be used without an arm
 tags:
   - Hardware
 url: https://en.rode.com/microphones/nt-usb_mini
-status: INACTIVE
+status: inactive
 image: rode.svg
 openSource:
 updated: 2022-12-01 20:24

--- a/src/content/uses/slack.md
+++ b/src/content/uses/slack.md
@@ -4,7 +4,7 @@ description: 'If there is a new side project with multiple people I tend to dire
 tags:
   - Software
 url: https://slack.com
-status: ACTIVE
+status: active
 image: slack.svg
 openSource:
 updated: 2022-12-01 20:34

--- a/src/content/uses/standard-notes.md
+++ b/src/content/uses/standard-notes.md
@@ -4,7 +4,7 @@ description: 'My knowledge base, see it as how others use Obsidian. Out of the b
 tags:
   - Software
 url: https://standardnotes.com/
-status: ACTIVE
+status: active
 image: standard_notes.png
 openSource: true
 updated: 2025-01-05 16:00

--- a/src/content/uses/svelte-kit.md
+++ b/src/content/uses/svelte-kit.md
@@ -4,7 +4,7 @@ description: 'Opinionated meta framework for Svelte (used for his website).'
 tags:
   - Development
 url: https://kit.svelte.dev/
-status: ACTIVE
+status: active
 image: sveltekit.svg
 openSource: true
 updated: 2023-11-25 16:35

--- a/src/content/uses/tech-pouch.md
+++ b/src/content/uses/tech-pouch.md
@@ -4,7 +4,7 @@ description: "Bring a little bit more organization to your tech. I'm not using i
 tags:
   - Essentials
 url: https://www.peakdesign.com/eu/products/tech-pouch?Size=Regular&Color=Black
-status: INACTIVE
+status: inactive
 image: tech_pouch.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/todoist.md
+++ b/src/content/uses/todoist.md
@@ -4,7 +4,7 @@ description: "My go-to todo list. It exists for that single purpose and doesn't 
 tags:
   - Software
 url: https://todoist.com/
-status: ACTIVE
+status: active
 image: todoist.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/vercel.md
+++ b/src/content/uses/vercel.md
@@ -4,7 +4,7 @@ description: 'Same as Netlify, but I prefer Vercel for projects with serverless 
 tags:
   - Development
 url: https://vercel.com/
-status: INACTIVE
+status: inactive
 image: vercel.svg
 openSource:
 updated: 2022-12-01 20:26

--- a/src/content/uses/vs-code.md
+++ b/src/content/uses/vs-code.md
@@ -4,7 +4,7 @@ description: "As I'm not a big fan of TextEdit (macOS) I use VS Code as my prima
 tags:
   - Software
 url: https://code.visualstudio.com/
-status: ACTIVE
+status: active
 image: vscode.svg
 openSource: true
 updated: 2022-12-01 20:35

--- a/src/content/uses/vuejs.md
+++ b/src/content/uses/vuejs.md
@@ -4,7 +4,7 @@ description: 'My favorite JS framework, as it lets you use what the web was made
 tags:
   - Development
 url: https://vuejs.org/
-status: INACTIVE
+status: inactive
 image: vue.svg
 openSource: true
 updated: 2022-12-01 20:32

--- a/src/content/uses/vueresumecomponent.md
+++ b/src/content/uses/vueresumecomponent.md
@@ -4,7 +4,7 @@ description: 'My first npm package which powered the CV of a previous version of
 tags:
   - Development
 url: https://www.npmjs.com/package/vue-resume-component
-status: INACTIVE
+status: inactive
 image: vueresumecomponent.svg
 openSource: true
 updated: 2022-12-01 20:32

--- a/src/content/uses/wandrd-backpack.md
+++ b/src/content/uses/wandrd-backpack.md
@@ -4,7 +4,7 @@ description: "I moved in 2024 and now have a longer way to work on my bike and a
 tags:
   - Essentials
 url: https://eu.wandrd.com/products/prvke?variant=39360658473002
-status: ACTIVE
+status: active
 image: wandrd.png
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/webstorm.md
+++ b/src/content/uses/webstorm.md
@@ -4,7 +4,7 @@ description: 'I like it as it just works and has all the features I need built-i
 tags:
   - Software
 url: https://www.jetbrains.com/webstorm/
-status: INACTIVE
+status: inactive
 image: webstorm.svg
 openSource:
 updated: 2022-12-01 20:30

--- a/src/content/uses/withings.md
+++ b/src/content/uses/withings.md
@@ -4,7 +4,7 @@ description: "Love that people don't spot that it is a Smart Watch. Love the mon
 tags:
   - Essentials
 url: https://www.withings.com/eu/en/scanwatch-2
-status: ACTIVE
+status: active
 image: withings_scan_watch.webp
 openSource:
 updated: 2025-01-05 16:00

--- a/src/content/uses/workflowy.md
+++ b/src/content/uses/workflowy.md
@@ -4,7 +4,7 @@ description: 'My go-to knowledge app, you could also call it a note app. Basical
 tags:
   - Software
 url: https://workflowy.com/
-status: INACTIVE
+status: inactive
 image: workflowy.jpeg
 openSource:
 updated: 2022-12-01 20:30

--- a/src/lib/components/Base/BaseStatus.svelte
+++ b/src/lib/components/Base/BaseStatus.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { StatusFilter } from '$lib/types/entry';
-	import { ProjectStatus, UsesEntryStatus } from '$lib/types/enums';
 	import Icon from '@iconify/svelte';
 
 	interface Props {
@@ -10,7 +9,7 @@
 	let { status }: Props = $props();
 </script>
 
-{#if status === UsesEntryStatus.Active || status === ProjectStatus.Active}
+{#if status === 'active'}
 	<Icon class="status-icon active" icon="ph:play-circle-bold" />
 {:else}
 	<Icon class="status-icon inactive" icon="ph:pause-circle-bold" />

--- a/src/lib/components/Entries/EntriesFilter.svelte
+++ b/src/lib/components/Entries/EntriesFilter.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import type { StatusFilter } from '$lib/types/entry';
-	import { ProjectStatus } from '$lib/types/enums';
 	import { statusFilterToArray, setParam } from '$lib/util/helper';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import BaseHeadlineIcon from '../Base/BaseHeadlineIcon.svelte';
@@ -14,14 +13,14 @@
 
 	let { statusEnum }: Props = $props();
 	const statuses = statusFilterToArray(statusEnum);
-	let status: StatusFilter = $state(ProjectStatus.All);
+	let status: StatusFilter = $state('all');
 	function onStatusChange() {
 		setParam('status', status);
 		dispatch('statusChange', status);
 	}
 
 	onMount(() => {
-		status = ($page.url.searchParams.get('status') as StatusFilter) || 'ALL';
+		status = ($page.url.searchParams.get('status') as StatusFilter) || 'all';
 	});
 </script>
 

--- a/src/lib/components/Entries/EntriesFilter.svelte
+++ b/src/lib/components/Entries/EntriesFilter.svelte
@@ -7,12 +7,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	interface Props {
-		statusEnum: StatusFilter;
-	}
-
-	let { statusEnum }: Props = $props();
-	const statuses = statusFilterToArray(statusEnum);
+	const statuses = statusFilterToArray();
 	let status: StatusFilter = $state('all');
 	function onStatusChange() {
 		setParam('status', status);

--- a/src/lib/data/projects/helper.ts
+++ b/src/lib/data/projects/helper.ts
@@ -59,6 +59,6 @@ export function sortByProperty(a: Project, b: Project, property: ProjectSortProp
 }
 
 function filterByStatus(entry: Project, filterStatus: ProjectStatus): boolean {
-	if (filterStatus === ProjectStatus.All) return true;
+	if (filterStatus === 'all') return true;
 	return entry.status === filterStatus;
 }

--- a/src/lib/data/uses/helper.ts
+++ b/src/lib/data/uses/helper.ts
@@ -62,6 +62,6 @@ export function sortByProperty(
 }
 
 function filterByStatus(entry: UsesEntry, filterStatus: UsesEntryStatus): boolean {
-	if (filterStatus === UsesEntryStatus.All) return true;
+	if (filterStatus === 'all') return true;
 	return entry.status === filterStatus;
 }

--- a/src/lib/types/entry.d.ts
+++ b/src/lib/types/entry.d.ts
@@ -1,4 +1,5 @@
 import {
+	ContentStatus,
 	EntryType,
 	PostSortProperty,
 	ProjectSortProperty,
@@ -56,4 +57,4 @@ export type SortProperty =
 	| UsesEntrySortProperty
 	| ShareableSortProperty;
 
-export type StatusFilter = ProjectStatus | UsesEntryStatus;
+export type StatusFilter = ContentStatus;

--- a/src/lib/types/entry.d.ts
+++ b/src/lib/types/entry.d.ts
@@ -3,10 +3,8 @@ import {
 	EntryType,
 	PostSortProperty,
 	ProjectSortProperty,
-	ProjectStatus,
 	ShareableSortProperty,
-	UsesEntrySortProperty,
-	UsesEntryStatus
+	UsesEntrySortProperty
 } from './enums';
 import type { Tag } from './tag';
 

--- a/src/lib/types/enums.ts
+++ b/src/lib/types/enums.ts
@@ -34,14 +34,9 @@ export const SORT_DEFAULTS = {
 	SHAREABLE: 'published' as const
 } as const;
 
-export enum ProjectStatus {
-	All = 'ALL',
-	Active = 'ACTIVE',
-	Inactive = 'INACTIVE'
-}
+// Single status type for all content
+export type ContentStatus = 'active' | 'inactive' | 'all';
 
-export enum UsesEntryStatus {
-	All = 'ALL',
-	Active = 'ACTIVE',
-	Inactive = 'INACTIVE'
-}
+// Aliases for specific content types (for backward compatibility)
+export type ProjectStatus = ContentStatus;
+export type UsesEntryStatus = ContentStatus;

--- a/src/lib/util/helper.test.ts
+++ b/src/lib/util/helper.test.ts
@@ -72,27 +72,22 @@ test('sortNumber - is A smaller than B', async () => {
 	expect(sortNumber(5, 10)).greaterThan(0);
 });
 
-test('statusFilterToArray - convert status filter enum to array', async () => {
-	const inputEnum = {
-		All: 'ALL',
-		Active: 'ACTIVE',
-		Inactive: 'INACTIVE'
-	};
+test('statusFilterToArray - convert status values to array', async () => {
 	const resultArray = [
 		{
-			display: 'All',
-			key: 'ALL'
-		},
-		{
 			display: 'Active',
-			key: 'ACTIVE'
+			key: 'active'
 		},
 		{
 			display: 'Inactive',
-			key: 'INACTIVE'
+			key: 'inactive'
+		},
+		{
+			display: 'All',
+			key: 'all'
 		}
 	];
-	expect(statusFilterToArray(inputEnum as any)).toEqual(resultArray);
+	expect(statusFilterToArray()).toEqual(resultArray);
 });
 
 test('sortDirectionsToArray - convert sort directions to array', async () => {

--- a/src/lib/util/helper.ts
+++ b/src/lib/util/helper.ts
@@ -72,16 +72,15 @@ export function isValidSortDirection(value: string): value is SortDirection {
 	return isValidSortProperty(value, SORT_DIRECTIONS);
 }
 
-// Type-safe enum to array conversion
+// Convert status values to array for UI display
 export function statusFilterToArray(
-	statusFilter: StatusFilter
+	statusFilter?: StatusFilter
 ): { display: string; key: string }[] {
-	return Object.keys(statusFilter).map((key) => {
-		return {
-			display: key,
-			key: String(statusFilter[key as keyof typeof statusFilter])
-		};
-	});
+	const statusValues: StatusFilter[] = ['active', 'inactive', 'all'];
+	return statusValues.map((value) => ({
+		display: value.charAt(0).toUpperCase() + value.slice(1),
+		key: value
+	}));
 }
 
 export function sortDirectionsToArray(): { display: string; key: string }[] {

--- a/src/lib/util/helper.ts
+++ b/src/lib/util/helper.ts
@@ -73,9 +73,7 @@ export function isValidSortDirection(value: string): value is SortDirection {
 }
 
 // Convert status values to array for UI display
-export function statusFilterToArray(
-	statusFilter?: StatusFilter
-): { display: string; key: string }[] {
+export function statusFilterToArray(): { display: string; key: string }[] {
 	const statusValues: StatusFilter[] = ['active', 'inactive', 'all'];
 	return statusValues.map((value) => ({
 		display: value.charAt(0).toUpperCase() + value.slice(1),

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -6,7 +6,6 @@
 	import type { UsesEntry } from '$lib/types/usesEntry';
 	import type { Post } from '$lib/types/post';
 	import type { PageData } from './$types';
-	import { UsesEntryStatus } from '$lib/types/enums';
 	// import type { Shareable } from '$lib/types/shareable'
 
 	// TODO: remove eager and only load images that got randomly selected
@@ -40,7 +39,7 @@
 	// const [shareables] = data.shareables
 
 	const priorityProjects = projects.filter((entry) => entry.prio >= 500);
-	const activeUses = uses.filter((entry) => entry.status === UsesEntryStatus.Active);
+	const activeUses = uses.filter((entry) => entry.status === 'active');
 	const randomProjects: Project[] = getRandomItems(priorityProjects, 2);
 	const randomUses: UsesEntry[] = getRandomItems(activeUses, 3);
 	const randomPosts: Post[] = getRandomItems(posts, 2);

--- a/src/routes/(main)/projects/+page.svelte
+++ b/src/routes/(main)/projects/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { filterAndSort } from '$lib/data/projects/helper';
-	import { ProjectStatus, SortDirection, SORT_DEFAULTS } from '$lib/types/enums';
+	import { SortDirection, SORT_DEFAULTS } from '$lib/types/enums';
 	import Entries from '$lib/components/Entries/Entries.svelte';
 	import BaseTag from '$lib/components/Base/BaseTag.svelte';
 	import Icon from '@iconify/svelte';
@@ -35,7 +35,7 @@
 	const [entries] = data.projects;
 
 	let filteredAndSorted = $derived(
-		filterAndSort(entries, 'all', ProjectStatus.All, SORT_DEFAULTS.PROJECT, SortDirection.Desc)
+		filterAndSort(entries, 'all', 'all', SORT_DEFAULTS.PROJECT, SortDirection.Desc)
 	);
 </script>
 

--- a/src/routes/(main)/uses/+page.svelte
+++ b/src/routes/(main)/uses/+page.svelte
@@ -3,7 +3,6 @@
 	import type { PageData } from './$types';
 	import Icon from '@iconify/svelte';
 	import { sortDate } from '$lib/util/helper';
-	import { UsesEntryStatus } from '$lib/types/enums';
 
 	const pictures = import.meta.glob(
 		'../../../assets/img/uses/*.{avif,gif,heif,jpeg,jpg,png,tiff,webp}',
@@ -43,8 +42,8 @@
 
 	const groupedEntriesOrder = ['Essentials', 'Hardware', 'Software', 'Development'];
 
-	const activeEntries = usesEntries.filter((entry) => entry.status === UsesEntryStatus.Active);
-	const inactiveEntries = usesEntries.filter((entry) => entry.status === UsesEntryStatus.Inactive);
+	const activeEntries = usesEntries.filter((entry) => entry.status === 'active');
+	const inactiveEntries = usesEntries.filter((entry) => entry.status === 'inactive');
 
 	const activeGroupedEntries: GroupedEntries[] = tags
 		.map((tag) => ({


### PR DESCRIPTION
Addresses issue #194

This PR refactors the status handling system by replacing `ProjectStatus` and `UsesEntryStatus` enums with a unified `ContentStatus` union type.

## Changes
- ✅ Replace duplicate enums with single union type
- ✅ Update all enum property access to string literals
- ✅ Migrate 59 content files to lowercase status values
- ✅ Modernize utility functions and components
- ✅ Remove unused imports and clean up codebase

## Benefits
- Reduced type complexity and duplication
- Consistent lowercase values following modern conventions
- Simplified filtering logic
- Better maintainability

Generated with [Claude Code](https://claude.ai/code)