### PR TITLE
refactor: simplify Entry interface hierarchy

### DIFF
--- a/src/lib/data/posts/helper.ts
+++ b/src/lib/data/posts/helper.ts
@@ -31,20 +31,19 @@ export function sortByProperty(a: Post, b: Post, property: PostSortProperty): nu
 }
 
 export function getPost(entry: RawEntry): Post {
-	const meta = entry.meta;
 	const type = EntryType.Post;
-	const slug = getSlug(meta.title);
+	const slug = getSlug(entry.title);
 	const relativePath = `/${type.toLowerCase()}s/${slug}`;
 	return {
 		type,
-		title: meta.title,
-		description: meta.description,
-		image: meta.image || '',
-		tags: meta.tags.map((tag: string) => getTag(tag, type)) || [],
-		published: getDate(meta.published),
-		updated: getDate(meta.updated),
-		tldr: meta.tldr || '',
-		discussion: meta.discussion || '',
+		title: entry.title,
+		description: entry.description,
+		image: entry.image || '',
+		tags: entry.tags.map((tag: string) => getTag(tag, type)) || [],
+		published: getDate(entry.published),
+		updated: getDate(entry.updated),
+		tldr: entry.tldr || '',
+		discussion: entry.discussion || '',
 		toc: entry.toc,
 		slug,
 		relativePath,

--- a/src/lib/data/projects/helper.ts
+++ b/src/lib/data/projects/helper.ts
@@ -33,7 +33,7 @@ export function getProject(entry: RawEntry): Project {
 		published: getDate(entry.published),
 		updated: getDate(entry.updated),
 		links: entry.links || [],
-		prio: entry.priority || 0, // Use priority field from flattened structure
+		prio: entry.prio || 0,
 		status: entry.status as ProjectStatus,
 		slug,
 		relativePath,

--- a/src/lib/data/projects/helper.ts
+++ b/src/lib/data/projects/helper.ts
@@ -20,22 +20,21 @@ export function filterAndSort(
 }
 
 export function getProject(entry: RawEntry): Project {
-	const meta = entry.meta;
 	const type = EntryType.Project;
-	const slug = getSlug(meta.title);
+	const slug = getSlug(entry.title);
 	const relativePath = `/${type.toLowerCase()}s/${slug}`;
 	return {
 		type,
-		title: meta.title,
-		image: meta.image || '',
-		imageAlt: meta.imageAlt || '',
-		description: meta.description || '',
-		tags: meta.tags.map((tag: string) => getTag(tag, type)) || [],
-		published: getDate(meta.published),
-		updated: getDate(meta.updated),
-		links: meta.links || [],
-		prio: meta.prio || 0,
-		status: meta.status as ProjectStatus,
+		title: entry.title,
+		image: entry.image || '',
+		imageAlt: entry.imageAlt || '',
+		description: entry.description || '',
+		tags: entry.tags.map((tag: string) => getTag(tag, type)) || [],
+		published: getDate(entry.published),
+		updated: getDate(entry.updated),
+		links: entry.links || [],
+		prio: entry.priority || 0, // Use priority field from flattened structure
+		status: entry.status as ProjectStatus,
 		slug,
 		relativePath,
 		fullPath: `https://harambasic.de${relativePath}`,

--- a/src/lib/data/shareable/helper.ts
+++ b/src/lib/data/shareable/helper.ts
@@ -18,19 +18,18 @@ export function filterAndSort(
 }
 
 export function getShareable(entry: RawEntry): Shareable {
-	const meta = entry.meta;
 	const type = EntryType.Shareable;
-	const slug = getSlug(meta.title);
+	const slug = getSlug(entry.title);
 	const relativePath = `/${type.toLowerCase()}s/${slug}`;
 	return {
 		type,
-		title: meta.title,
-		description: meta.description,
+		title: entry.title,
+		description: entry.description,
 		comment: '', // TODO fix mapping
-		tags: meta.tags.map((tag: string) => getTag(tag, type)) || [],
-		published: getDate(meta.published),
-		updated: getDate(meta.updated),
-		url: meta.url || '',
+		tags: entry.tags.map((tag: string) => getTag(tag, type)) || [],
+		published: getDate(entry.published),
+		updated: getDate(entry.updated),
+		url: entry.url || '',
 		slug,
 		relativePath,
 		fullPath: `https://harambasic.de${relativePath}`

--- a/src/lib/data/uses/helper.ts
+++ b/src/lib/data/uses/helper.ts
@@ -20,24 +20,20 @@ export function filterAndSort(
 }
 
 export function getUsesEntry(entry: RawEntry): UsesEntry {
-	if (!entry.meta) {
-		throw new Error('Missing meta data');
-	}
-	const meta = entry.meta;
 	const type = EntryType.UsesEntry;
-	const slug = getSlug(meta.title);
+	const slug = getSlug(entry.title);
 	const relativePath = `/uses/${slug}`;
 	return {
 		type,
-		title: meta.title,
-		description: meta.description,
-		image: meta.image || '',
-		tags: meta.tags.map((tag: string) => getTag(tag, type)) || [],
-		published: getDate(meta.published),
-		updated: getDate(meta.updated),
-		url: meta.url || '',
-		status: meta.status as UsesEntryStatus,
-		openSource: meta.openSource || false,
+		title: entry.title,
+		description: entry.description,
+		image: entry.image || '',
+		tags: entry.tags.map((tag: string) => getTag(tag, type)) || [],
+		published: getDate(entry.published),
+		updated: getDate(entry.updated),
+		url: entry.url || '',
+		status: entry.status as UsesEntryStatus,
+		openSource: entry.openSource || false,
 		slug,
 		relativePath,
 		fullPath: `https://harambasic.de${relativePath}`

--- a/src/lib/data/uses/helper.ts
+++ b/src/lib/data/uses/helper.ts
@@ -23,16 +23,22 @@ export function getUsesEntry(entry: RawEntry): UsesEntry {
 	const type: EntryType = 'uses';
 	const slug = getSlug(entry.title);
 	const relativePath = `/uses/${slug}`;
+	
+	// Validate required fields
+	if (!entry.title || !entry.description || !entry.published || !entry.updated) {
+		throw new Error(`Missing required fields in uses entry: ${entry.title || 'untitled'}`);
+	}
+	
 	return {
 		type,
 		title: entry.title,
 		description: entry.description,
 		image: entry.image || '',
-		tags: entry.tags.map((tag: string) => getTag(tag, type)) || [],
+		tags: entry.tags?.map((tag: string) => getTag(tag, type)) || [],
 		published: getDate(entry.published),
 		updated: getDate(entry.updated),
 		url: entry.url || '',
-		status: entry.status as UsesEntryStatus,
+		status: (entry.status as UsesEntryStatus) || 'active',
 		openSource: entry.openSource || false,
 		slug,
 		relativePath,

--- a/src/lib/data/uses/helper.ts
+++ b/src/lib/data/uses/helper.ts
@@ -23,12 +23,12 @@ export function getUsesEntry(entry: RawEntry): UsesEntry {
 	const type: EntryType = 'uses';
 	const slug = getSlug(entry.title);
 	const relativePath = `/uses/${slug}`;
-	
+
 	// Validate required fields
 	if (!entry.title || !entry.description || !entry.published || !entry.updated) {
 		throw new Error(`Missing required fields in uses entry: ${entry.title || 'untitled'}`);
 	}
-	
+
 	return {
 		type,
 		title: entry.title,

--- a/src/lib/types/entry.d.ts
+++ b/src/lib/types/entry.d.ts
@@ -42,10 +42,10 @@ export interface EntryDate {
 
 /**
  * Base processed entry interface that serves as the foundation for all content types.
- * 
+ *
  * This interface represents the core structure after raw content has been processed,
  * with computed fields like slug and paths, and transformed data like parsed dates and tags.
- * 
+ *
  * @interface BaseEntry
  * @property {EntryType} type - The type of content (post, project, uses, shareable)
  * @property {string} slug - URL-friendly version of the title

--- a/src/lib/types/entry.d.ts
+++ b/src/lib/types/entry.d.ts
@@ -8,27 +8,31 @@ import {
 	UsesEntryStatus
 } from './enums';
 import type { Tag } from './tag';
+import type { Link } from './generic';
+import type { TocNode } from './post';
 
+// Flattened raw entry structure - no nested meta
 export interface RawEntry {
+	// Content
 	html: string;
-	meta: RawEntryMeta;
 	toc: TocNode[];
-}
-
-export interface RawEntryMeta {
+	
+	// Frontmatter (flattened, no nested meta)
 	title: string;
 	description: string;
 	image: string;
 	tags: string[];
 	published: string;
 	updated: string;
+	
+	// Optional fields
 	url?: string;
-	status?: StatusFilter;
+	status?: ContentStatus;
 	openSource?: boolean;
 	tldr?: string;
 	discussion?: string;
 	links?: Link[];
-	prio?: number;
+	priority?: number; // renamed from prio for consistency
 	imageAlt?: string;
 }
 
@@ -37,18 +41,22 @@ export interface EntryDate {
 	display: string;
 }
 
-export interface Entry {
+// Base processed entry interface
+export interface BaseEntry {
 	type: EntryType;
+	slug: string;
+	relativePath: string;
+	fullPath: string;
 	title: string;
 	description: string;
 	image: string;
 	tags: Tag[];
 	published: EntryDate;
 	updated: EntryDate;
-	slug: string;
-	relativePath: string;
-	fullPath: string;
 }
+
+// Legacy Entry interface for backward compatibility - maps to BaseEntry
+export interface Entry extends BaseEntry {}
 
 export type SortProperty =
 	| PostSortProperty
@@ -56,4 +64,7 @@ export type SortProperty =
 	| UsesEntrySortProperty
 	| ShareableSortProperty;
 
-export type StatusFilter = ProjectStatus | UsesEntryStatus;
+export type ContentStatus = ProjectStatus | UsesEntryStatus;
+
+// Legacy type alias for backward compatibility
+export type StatusFilter = ContentStatus;

--- a/src/lib/types/entry.d.ts
+++ b/src/lib/types/entry.d.ts
@@ -32,7 +32,7 @@ export interface RawEntry {
 	tldr?: string;
 	discussion?: string;
 	links?: Link[];
-	priority?: number; // renamed from prio for consistency
+	prio?: number;
 	imageAlt?: string;
 }
 
@@ -56,7 +56,7 @@ export interface BaseEntry {
 }
 
 // Legacy Entry interface for backward compatibility - maps to BaseEntry
-export interface Entry extends BaseEntry {}
+export type Entry = BaseEntry;
 
 export type SortProperty =
 	| PostSortProperty

--- a/src/lib/types/entry.d.ts
+++ b/src/lib/types/entry.d.ts
@@ -16,7 +16,7 @@ export interface RawEntry {
 	// Content
 	html: string;
 	toc: TocNode[];
-	
+
 	// Frontmatter (flattened, no nested meta)
 	title: string;
 	description: string;
@@ -24,7 +24,7 @@ export interface RawEntry {
 	tags: string[];
 	published: string;
 	updated: string;
-	
+
 	// Optional fields
 	url?: string;
 	status?: ContentStatus;

--- a/src/lib/types/entry.d.ts
+++ b/src/lib/types/entry.d.ts
@@ -40,7 +40,24 @@ export interface EntryDate {
 	display: string;
 }
 
-// Base processed entry interface
+/**
+ * Base processed entry interface that serves as the foundation for all content types.
+ * 
+ * This interface represents the core structure after raw content has been processed,
+ * with computed fields like slug and paths, and transformed data like parsed dates and tags.
+ * 
+ * @interface BaseEntry
+ * @property {EntryType} type - The type of content (post, project, uses, shareable)
+ * @property {string} slug - URL-friendly version of the title
+ * @property {string} relativePath - Relative path for routing (e.g., "/posts/my-post")
+ * @property {string} fullPath - Complete URL including domain
+ * @property {string} title - Content title
+ * @property {string} description - Content description/summary
+ * @property {string} image - Main image URL or path
+ * @property {Tag[]} tags - Processed tag objects with metadata
+ * @property {EntryDate} published - Parsed publication date with display format
+ * @property {EntryDate} updated - Parsed update date with display format
+ */
 export interface BaseEntry {
 	type: EntryType;
 	slug: string;

--- a/src/lib/types/post.d.ts
+++ b/src/lib/types/post.d.ts
@@ -1,4 +1,4 @@
-import type { Entry } from './entry';
+import type { BaseEntry } from './entry';
 
 export interface TocNode {
 	depth: number;
@@ -7,7 +7,7 @@ export interface TocNode {
 	children?: TocNode[] | [];
 }
 
-export interface Post extends Entry {
+export interface Post extends BaseEntry {
 	toc: TocNode[];
 	tldr: string;
 	discussion: string;

--- a/src/lib/types/project.d.ts
+++ b/src/lib/types/project.d.ts
@@ -1,8 +1,8 @@
-import type { Entry } from './entry';
+import type { BaseEntry } from './entry';
 import { ProjectStatus } from './enums';
 import type { Link } from './generic';
 
-export interface Project extends Entry {
+export interface Project extends BaseEntry {
 	links: Link[];
 	prio: number;
 	status: ProjectStatus;

--- a/src/lib/types/shareable.d.ts
+++ b/src/lib/types/shareable.d.ts
@@ -1,6 +1,6 @@
-import type { Entry } from './entry';
+import type { BaseEntry } from './entry';
 
-export interface Shareable extends Omit<Entry, 'image'> {
+export interface Shareable extends Omit<BaseEntry, 'image'> {
 	url: string;
 	comment: string;
 }

--- a/src/lib/types/usesEntry.ts
+++ b/src/lib/types/usesEntry.ts
@@ -1,7 +1,7 @@
-import type { Entry } from './entry';
+import type { BaseEntry } from './entry';
 import type { UsesEntryStatus } from './enums';
 
-export interface UsesEntry extends Entry {
+export interface UsesEntry extends BaseEntry {
 	url: string;
 	status: UsesEntryStatus;
 	openSource: boolean;

--- a/src/lib/util/converter.server.ts
+++ b/src/lib/util/converter.server.ts
@@ -18,12 +18,12 @@ import type { RawEntry, ContentStatus } from '$lib/types/entry';
 
 /**
  * Interface for frontmatter data extracted from markdown files.
- * 
+ *
  * Required fields:
  * - title, description, image: Basic content metadata
  * - tags: Array of tag strings for categorization
  * - published, updated: ISO date strings for content lifecycle
- * 
+ *
  * Optional fields:
  * - status: Content status (draft, active, etc.)
  * - url: External link for the content
@@ -70,15 +70,22 @@ export async function getRawEntries(entryType: EntryType): Promise<RawEntry[]> {
 		files.map(async (file): Promise<RawEntry> => {
 			const output = processor.processSync(file);
 			const frontmatter = output.data.frontmatter as FrontmatterData;
-			
+
 			// Validate required fields
 			if (!frontmatter) {
 				throw new Error(`Missing frontmatter in ${entryType} entry`);
 			}
-			if (!frontmatter.title || !frontmatter.description || !frontmatter.published || !frontmatter.updated) {
-				throw new Error(`Missing required frontmatter fields in ${entryType} entry: ${frontmatter.title || 'untitled'}`);
+			if (
+				!frontmatter.title ||
+				!frontmatter.description ||
+				!frontmatter.published ||
+				!frontmatter.updated
+			) {
+				throw new Error(
+					`Missing required frontmatter fields in ${entryType} entry: ${frontmatter.title || 'untitled'}`
+				);
 			}
-			
+
 			return {
 				html: String(output.value),
 				toc: output.data.toc as TocNode[],

--- a/src/lib/util/converter.server.ts
+++ b/src/lib/util/converter.server.ts
@@ -14,7 +14,7 @@ import remarkRehype from 'remark-rehype';
 import type { VFile } from 'vfile';
 import type { Node } from 'unist';
 import { visit } from 'unist-util-visit';
-import type { RawEntry } from '$lib/types/entry';
+import type { RawEntry, ContentStatus } from '$lib/types/entry';
 
 interface FrontmatterData {
 	title: string;
@@ -24,7 +24,7 @@ interface FrontmatterData {
 	published: string;
 	updated: string;
 	url?: string;
-	status?: string;
+	status?: ContentStatus;
 	openSource?: boolean;
 	tldr?: string;
 	discussion?: string;

--- a/src/lib/util/converter.server.ts
+++ b/src/lib/util/converter.server.ts
@@ -14,7 +14,7 @@ import remarkRehype from 'remark-rehype';
 import type { VFile } from 'vfile';
 import type { Node } from 'unist';
 import { visit } from 'unist-util-visit';
-import type { RawEntry, RawEntryMeta } from '$lib/types/entry';
+import type { RawEntry } from '$lib/types/entry';
 
 // todo maybe markdown file?
 const processor = remark()
@@ -36,8 +36,9 @@ export async function getRawEntries(entryType: EntryType): Promise<RawEntry[]> {
 			const output = processor.processSync(file);
 			return {
 				html: String(output.value),
-				meta: output.data.frontmatter as RawEntryMeta,
-				toc: output.data.toc as TocNode[]
+				toc: output.data.toc as TocNode[],
+				// Flatten frontmatter fields directly into the object
+				...(output.data.frontmatter as any)
 			};
 		})
 	);

--- a/src/lib/util/converter.server.ts
+++ b/src/lib/util/converter.server.ts
@@ -16,6 +16,23 @@ import type { Node } from 'unist';
 import { visit } from 'unist-util-visit';
 import type { RawEntry } from '$lib/types/entry';
 
+interface FrontmatterData {
+	title: string;
+	description: string;
+	image: string;
+	tags: string[];
+	published: string;
+	updated: string;
+	url?: string;
+	status?: string;
+	openSource?: boolean;
+	tldr?: string;
+	discussion?: string;
+	links?: Array<{ title: string; url: string }>;
+	prio?: number;
+	imageAlt?: string;
+}
+
 // todo maybe markdown file?
 const processor = remark()
 	.use(remarkFrontmatter)
@@ -38,7 +55,7 @@ export async function getRawEntries(entryType: EntryType): Promise<RawEntry[]> {
 				html: String(output.value),
 				toc: output.data.toc as TocNode[],
 				// Flatten frontmatter fields directly into the object
-				...(output.data.frontmatter as any)
+				...(output.data.frontmatter as FrontmatterData)
 			};
 		})
 	);


### PR DESCRIPTION
Resolves #195

This PR implements the Entry interface hierarchy refactoring by:

- Flattening RawEntry structure by removing nested RawEntryMeta
- Creating BaseEntry interface as foundation for all processed entries
- Updating content processing to use object spread instead of nested meta
- Updating all helper functions for direct property access
- Maintaining backward compatibility with Entry interface alias

Generated with [Claude Code](https://claude.ai/code)