### PR TITLE
Entries image loading placeholder

### DIFF
--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -37,12 +37,6 @@
 		}
 	}
 
-	type FeedImageEntry = Pick<MergedFeedEntry, 'category' | 'slug'>;
-
-	function getFeedImageKey(entry: FeedImageEntry): string {
-		return `${entry.category}:${entry.slug}`;
-	}
-
 	interface Props {
 		data: PageData;
 	}
@@ -63,7 +57,6 @@
 	let visibleCount = $state<number | null>(null);
 	let effectiveVisibleCount = $derived(visibleCount ?? initialCount);
 	let visibleEntries = $derived(layoutOrdered.slice(0, effectiveVisibleCount));
-	let loadedFeedImages = $state<Record<string, boolean>>({});
 
 	let feedRows = $derived.by(() => {
 		const entries = visibleEntries;
@@ -88,66 +81,53 @@
 		return rows;
 	});
 
-	function markFeedImageLoaded(entry: FeedImageEntry): void {
-		const key = getFeedImageKey(entry);
-		if (loadedFeedImages[key]) {
-			return;
-		}
-		loadedFeedImages[key] = true;
-	}
-
-	function isFeedImageLoaded(entry: FeedImageEntry): boolean {
-		return loadedFeedImages[getFeedImageKey(entry)] === true;
-	}
-
-	function trackFeedImageLoad(node: HTMLElement, entry: FeedImageEntry) {
-		let trackedEntry = entry;
+	function trackFeedImageLoad(node: HTMLElement) {
 		let trackedImage: HTMLImageElement | null = null;
-		let isResolved = false;
-
-		const handleDone = () => {
-			if (isResolved) {
-				return;
-			}
-			isResolved = true;
-			markFeedImageLoaded(trackedEntry);
-			cleanup();
-		};
+		let trackedObserver: MutationObserver | null = null;
 
 		const cleanup = () => {
-			if (trackedImage === null) {
-				return;
+			if (trackedImage !== null) {
+				trackedImage.removeEventListener('load', markLoaded);
+				trackedImage.removeEventListener('error', markLoaded);
+				trackedImage = null;
 			}
-			trackedImage.removeEventListener('load', handleDone);
-			trackedImage.removeEventListener('error', handleDone);
+			if (trackedObserver !== null) {
+				trackedObserver.disconnect();
+				trackedObserver = null;
+			}
 		};
 
-		const setup = () => {
+		const markLoaded = () => {
+			node.classList.add('loaded');
 			cleanup();
-			isResolved = false;
-			trackedImage = node.querySelector('img');
-			if (trackedImage === null) {
-				handleDone();
-				return;
-			}
-			if (trackedImage.complete) {
-				handleDone();
-				return;
-			}
-			trackedImage.addEventListener('load', handleDone, { once: true });
-			trackedImage.addEventListener('error', handleDone, { once: true });
 		};
 
-		setup();
+		const connectToImage = (): boolean => {
+			const image = node.querySelector('img');
+			if (image === null) {
+				return false;
+			}
+			trackedImage = image;
+			if (trackedImage.complete) {
+				markLoaded();
+				return true;
+			}
+			trackedImage.addEventListener('load', markLoaded, { once: true });
+			trackedImage.addEventListener('error', markLoaded, { once: true });
+			return true;
+		};
+
+		if (!connectToImage()) {
+			trackedObserver = new MutationObserver(() => {
+				if (connectToImage()) {
+					trackedObserver?.disconnect();
+					trackedObserver = null;
+				}
+			});
+			trackedObserver.observe(node, { childList: true, subtree: true });
+		}
 
 		return {
-			update(nextEntry: FeedImageEntry) {
-				trackedEntry = nextEntry;
-				if (isFeedImageLoaded(trackedEntry)) {
-					return;
-				}
-				setup();
-			},
 			destroy() {
 				cleanup();
 			}
@@ -213,35 +193,21 @@
 											{#if entry.category === 'Posts'}
 												<Icon icon="ph:file-text-duotone" class="thumb-icon" />
 											{:else if entry.image && isSvgImage(entry.image)}
-												{@const thumbLoaded = isFeedImageLoaded(entry)}
-												{#if !thumbLoaded}
-													<span class="thumb-loader" aria-hidden="true"></span>
-												{/if}
-												<div
-													class="thumb-media"
-													class:loaded={thumbLoaded}
-													use:trackFeedImageLoad={entry}
-												>
+												<div class="thumb-media" use:trackFeedImageLoad>
 													<img src={getSvgSrc(entry.category, entry.image)} alt={entry.title} />
 												</div>
+												<span class="thumb-loader" aria-hidden="true"></span>
 											{:else if entry.image}
 												{@const imageData = getEntryImage(entry)}
 												{#if imageData}
-													{@const thumbLoaded = isFeedImageLoaded(entry)}
-													{#if !thumbLoaded}
-														<span class="thumb-loader" aria-hidden="true"></span>
-													{/if}
-													<div
-														class="thumb-media"
-														class:loaded={thumbLoaded}
-														use:trackFeedImageLoad={entry}
-													>
+													<div class="thumb-media" use:trackFeedImageLoad>
 														<enhanced:img
 															src={imageData}
 															sizes="(min-width:768px) 64px, 48px"
 															alt={entry.title}
 														/>
 													</div>
+													<span class="thumb-loader" aria-hidden="true"></span>
 												{:else}
 													<Icon icon="ph:empty-duotone" class="thumb-icon" />
 												{/if}
@@ -462,6 +428,7 @@
 								overflow: hidden;
 								.thumb-loader {
 									display: block;
+									opacity: 1;
 									position: absolute;
 									top: 50%;
 									left: 50%;
@@ -470,6 +437,7 @@
 									height: 0.75rem;
 									border-radius: 50%;
 									background: color-mix(in srgb, var(--c-font-accent-super-light) 65%, transparent);
+									transition: opacity 180ms ease-out;
 									animation: feed-thumb-pulse 2.2s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
 									transform: translate(-50%, -50%);
 									transform-origin: center;
@@ -486,6 +454,10 @@
 									transition: opacity 220ms ease-out;
 									&.loaded {
 										opacity: 1;
+										~ .thumb-loader {
+											opacity: 0;
+											animation: none;
+										}
 									}
 									img {
 										display: block;


### PR DESCRIPTION
Adds a pulsating CSS loading placeholder to home page feed images for a smoother user experience during content loading.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ff3ce80e-128c-4fa8-8c94-9a637bc86914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ff3ce80e-128c-4fa8-8c94-9a637bc86914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

