### PR TITLE
docs: replace generic create-svelte README with project-specific one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,29 @@
-# create-svelte
+# harambasic.de
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte).
+Luka's personal website and consulting portfolio. Built with SvelteKit, deployed on Netlify.
 
-## Creating a project
+## Stack
 
-If you're seeing this, you've probably already done this step. Congrats!
+- **Framework:** SvelteKit 5 with static adapter
+- **Package manager:** Bun
+- **Node:** 24+
+- **Deployment:** Netlify
 
-```bash
-# create a new project in the current directory
-npm create svelte@latest
-
-# create a new project in my-app
-npm create svelte@latest my-app
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+## Local development
 
 ```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+bun install
+bun run dev
 ```
 
-## Building
-
-To create a production version of your app:
+## Quality checks
 
 ```bash
-npm run build
+bun run validate   # format → typecheck → lint → test → build
 ```
 
-You can preview the production build with `npm run preview`.
+Run this before pushing. Fix any failures before opening a PR.
 
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+## Deploy
 
-## Data structure
-
-- random data accessed on home
-- one general feed with posts, bookmarks and projects - later maybe posts from mastodon
-- posts, bookmarks and projects need their dedicated tags - so only tags that are used in this category
-- there also needs to be a combined tags list from posts, bookmarks and projects
-- also filter needs to work
+Netlify builds automatically on merge to `main`. Build command: `bun run build`, output: `build/`.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Run this before pushing. Fix any failures before opening a PR.
 ## Deploy
 
 Netlify builds automatically on merge to `main`. Build command: `bun run build`, output: `build/`.
+
+---
+
+_Last updated: 2026-04-03_


### PR DESCRIPTION
## Summary

Replaces the default `create-svelte` boilerplate README with a minimal, accurate README for harambasic.de — covering the actual stack, local dev setup, quality checks, and deploy process.

## Changes

- `README.md` — rewritten from scratch

## Quality Checks

- Typecheck: n/a (docs only)
- Tests: n/a
- Lint: n/a

---
*Created by Agentos (slack_harambasicde)*