### PR TITLE
perf: faster view transitions and eager LCP profile image

### DIFF
--- a/scripts/audit-slugs.js
+++ b/scripts/audit-slugs.js
@@ -33,7 +33,7 @@ function getSlug(str) {
 }
 
 const CONTENT = join(process.cwd(), 'src', 'content');
-const SOCIAL = join(process.cwd(), 'static', 'social');
+const SOCIAL = join(process.cwd(), 'public', 'social');
 const TYPES = ['posts', 'projects', 'uses', 'work'];
 
 function loadEntries(type) {
@@ -106,7 +106,7 @@ for (const type of ['posts', 'uses']) {
 	for (const e of all[type]) {
 		const png = join(SOCIAL, `${e.slug}.png`);
 		if (!existsSync(png)) {
-			console.warn(`WARN  missing social image: static/social/${e.slug}.png (${type}/${e.file})`);
+			console.warn(`WARN  missing social image: public/social/${e.slug}.png (${type}/${e.file})`);
 			warn++;
 		}
 	}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,7 +4,7 @@ import '../styles/fonts.css';
 import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/code.css';
-import { ClientRouter } from 'astro:transitions';
+import { ClientRouter, fade } from 'astro:transitions';
 import LayoutHeader from '../components/LayoutHeader.astro';
 import LayoutFooter from '../components/LayoutFooter.astro';
 import ContactDialog from '../components/ContactDialog.astro';
@@ -27,7 +27,7 @@ const socialImgAlt = fullTitle;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" transition:animate={fade({ duration: '0.08s' })}>
 	<head>
 		<meta charset="utf-8" />
 		<ClientRouter />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -87,12 +87,19 @@ const initialRows = rowSteps[0] ?? allRows.length;
 <Layout description={description}>
 	<section class="heyho">
 		<div class="inner">
+			{
+				/* LCP element: load eagerly at high priority, sized to its real display width
+			    (14.5rem desktop, full container width below 32rem) instead of the shared
+			    detail-page widths — the old sizes pulled the 1280w variant for a ~350px slot. */
+			}
 			<Image
 				src={profileImg}
 				alt="Profile of Luka Harambasic"
 				class="profile"
-				widths={IMAGE_WIDTHS}
-				sizes="(min-width:1920px) 1280px, (min-width:1080px) 640px, (min-width:768px) 400px"
+				widths={[232, 464, 696]}
+				sizes="(max-width: 32rem) calc(100vw - 4rem), 14.5rem"
+				loading="eager"
+				fetchpriority="high"
 			/>
 			<div class="content">
 				<BaseRichText>


### PR DESCRIPTION
Stacked on #255 — performance follow-ups from the deploy-preview Lighthouse run.

## Changes

- **Faster page transitions**: `transition:animate={fade({ duration: '0.08s' })}` on `<html>` cuts the view-transition fade from Astro's 180ms default to 80ms. The `prefers-reduced-motion` guard in `base.css` still zeroes it out.
- **LCP fix (3.5s → expected <2s)**: the homepage profile image is the LCP element but was lazy-loaded at `fetchpriority=auto`, and its `sizes` attribute claimed up to 1280px display for a ~232px (desktop) / ~350px (mobile) slot, pulling the 67KB 1280w variant. Now `loading="eager"` + `fetchpriority="high"` with `widths={[232, 464, 696]}` matching the actual CSS.
- **audit-slugs fix**: the social-image check still pointed at `static/social`, which no longer exists after the move to `public/` — every post/uses entry false-warned as missing its og:image.

## Validation

- `astro check`: 0 errors
- Vitest: 109 passed
- Playwright parity suite: 39 passed
- `bun run lint` + build: clean; built homepage carries `fetchpriority="high"` and `animation-duration: 0.08s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)